### PR TITLE
Add Docker Monitoring Setup with Grafana and Prometheus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:latest
+COPY index.html /usr/share/nginx/html/index.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  nginx:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:80"
+    networks:
+      - monitoring
+
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: example_password
+    volumes:
+      - mysql-data:/var/lib/mysql
+    networks:
+      - monitoring
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:latest
+    volumes:
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - monitoring
+
+networks:
+  monitoring:
+    driver: bridge
+
+volumes:
+  mysql-data:
+  prometheus-data:
+  grafana-data:

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Docker Monitoring</title>
+</head>
+<body>
+    <h1>Welcome to Docker Monitoring</h1>
+    <p>This is a custom Nginx page for monitoring.</p>
+    <p>But this time we are doing in unbuntu</p>
+</body>
+</html>

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'docker'
+    static_configs:
+      - targets: ['192.168.20.37:9323']


### PR DESCRIPTION
This PR 
![Screenshot 2025-03-31 120048](https://github.com/user-attachments/assets/19588d79-0ee6-4b9b-97ce-f61070cf70d6)
adds the initial setup for a Docker monitoring stack using Grafana and Prometheus. It includes:
- Dockerfile for building the necessary containers
- docker-compose.yml to orchestrate the services
- prometheus.yml for Prometheus configuration
- index.html for a basic web interface